### PR TITLE
Minor bug fix

### DIFF
--- a/atdtool
+++ b/atdtool
@@ -170,7 +170,7 @@ def showerrs(filename, fd, errs):
         exactstr = ''
         if not t.find(e.precontext, e.string):
             exactstr = ' (?)'
-        print('%s:%d:%d:%s %s "%s"' % (filename, t.line, t.col, exactstr, e.description, t.words))
+        print('%s:%d:%d:%s %s "%s"' % (filename, t.line, t.col, exactstr, e.description, t.words if hasattr(t, 'words') else ''))
         if len(e.suggestions) > 0:
             print('  suggestions: %s' % ', '.join(e.suggestions))
 


### PR DESCRIPTION
In some files t.words is undefined in showerrs. This makes the program crash and not print anything more.

I have added a check and if it's undefined the printout will be an empty string.

After my changes I get:
filename.tex:49:1: (?) Spelling ""
poiniting at the last (empty)  line in my file.
