### PR TITLE
Possibility to pass PREFIX, BINDIR, and MANDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
-PREFIX=/usr/local
-BINDIR=$(PREFIX)/bin
-MANDIR=$(PREFIX)/share/man
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+MANDIR ?= $(PREFIX)/share/man
 
 CFLAGS=-Wall -Werror
 


### PR DESCRIPTION
This change makes it possible to pass PREFIX and more as env vars so the
install location can be changed easier than by editing the Makefile.
